### PR TITLE
Add Breakout reinforcement learning example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# reinforcement-learning
+# Reinforcement Learning
+
+This repository contains a simple example of training a DQN agent to play the Atari game **Breakout** using Python.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install stable-baselines3[extra] gym[atari]
+   ```
+
+2. Run training:
+   ```bash
+   python dqn_breakout.py
+   ```
+
+The training script will save the model to `dqn_breakout.zip` when finished.

--- a/dqn_breakout.py
+++ b/dqn_breakout.py
@@ -1,0 +1,31 @@
+import gym
+from stable_baselines3 import DQN
+from stable_baselines3.common.atari_wrappers import AtariWrapper
+from stable_baselines3.common.vec_env import DummyVecEnv
+from stable_baselines3.common.monitor import Monitor
+
+
+def make_env():
+    env = gym.make("BreakoutNoFrameskip-v4")
+    env = AtariWrapper(env)
+    env = Monitor(env)
+    return env
+
+
+def main():
+    env = DummyVecEnv([make_env])
+    model = DQN(
+        "CnnPolicy",
+        env,
+        verbose=1,
+        buffer_size=50000,
+        learning_starts=10000,
+        target_update_interval=1000,
+        exploration_fraction=0.1,
+    )
+    model.learn(total_timesteps=100000)
+    model.save("dqn_breakout")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add README content describing DQN example
- add `dqn_breakout.py` demonstrating how to train a DQN agent on Breakout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f504e8b8832da6ff7a622f88254c